### PR TITLE
音声認識で、Error7が発生すると、Error8が発生し続ける問題の修正

### DIFF
--- a/src/recognize_voice_activity.rb
+++ b/src/recognize_voice_activity.rb
@@ -84,12 +84,10 @@ class RecognizeVoiceActivity
       $recognizing_voice_intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE, 'ja_JP')
       $recognizing_voice_intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE_MODEL,
                                          RecognizerIntent::LANGUAGE_MODEL_FREE_FORM)
-    end
-    # 音声のMute,unMute処理を繰り返し行うには、Activity全体で1つのAudioManagerを使わなければいけないルール。
-    # リスナーでも同じManagerを使えるよう，Global変数にしている．
-    $audio_manager = @context.getSystemService(Context::AUDIO_SERVICE)
-    $audio_manager.setStreamMute(AudioManager::STREAM_SYSTEM, true)
 
+      audio_manager = @context.getSystemService(Context::AUDIO_SERVICE)
+      audio_manager.setStreamMute(AudioManager::STREAM_SYSTEM, true)
+    end
     $speech_recognizer.start_listening($recognizing_voice_intent)
   end
 

--- a/src/recognize_voice_activity.rb
+++ b/src/recognize_voice_activity.rb
@@ -86,8 +86,18 @@ class RecognizeVoiceActivity
                                          RecognizerIntent::LANGUAGE_MODEL_FREE_FORM)
 
       audio_manager = @context.getSystemService(Context::AUDIO_SERVICE)
-      audio_manager.setStreamMute(AudioManager::STREAM_SYSTEM, true)
+      audio_manager.setStreamMute(AudioManager::STREAM_MUSIC, true)
+
+      $ohayo_sound_resids = [R.raw.ohayo1, R.raw.ohayo2, R.raw.ohayo3, R.raw.ohayo4, R.raw.ohayo5, R.raw.ohayo6, R.raw.ohayo7, R.raw.ohayo8]
+      $otsukare_sound_resids = [R.raw.otsukare1, R.raw.otsukare2, R.raw.otsukare3, R.raw.otsukare4, R.raw.otsukare5, R.raw.otsukare6, R.raw.otsukare7, R.raw.otsukare8, R.raw.otsukare9, R.raw.otsukare10, R.raw.otsukare11, R.raw.otsukare12]
+      $player_ohayo = MediaPlayer.new
+      $player_otsukare = MediaPlayer.new
     end
+    ohayo_sound_resid = $ohayo_sound_resids[rand(8)]
+    otsukare_sound_resid = $otsukare_sound_resids[rand(12)]
+    prepare_greeting_player $player_ohayo, ohayo_sound_resid
+    prepare_greeting_player $player_otsukare, otsukare_sound_resid
+
     $speech_recognizer.start_listening($recognizing_voice_intent)
   end
 
@@ -107,5 +117,13 @@ class RecognizeVoiceActivity
           image_view  :image_resource => $package::R.drawable.ohayogozaimax_face_starting_up,
                       :layout => {:width => :wrap_content, :height => :wrap_content}
         end
+  end
+
+  def prepare_greeting_player player, greeting_resid
+    Log.v 'debug', 'prepare greeting player'
+    greeting_uri = Uri.parse("android.resource://com.ohayoman_app/#{greeting_resid}")
+    player.set_data_source(@context, greeting_uri)
+    player.set_audio_stream_type(AudioManager::STREAM_DTMF)
+    player.prepare
   end
 end

--- a/src/recognize_voice_activity.rb
+++ b/src/recognize_voice_activity.rb
@@ -2,6 +2,7 @@
 require 'ruboto/activity'
 require 'ruboto/util/toast'
 require 'ruboto/widget'
+require_relative 'speech_listener.rb'
 
 java_import 'android.speech.RecognizerIntent'
 java_import 'android.speech.SpeechRecognizer'
@@ -21,7 +22,6 @@ java_import 'org.apache.http.message.BasicNameValuePair'
 java_import 'org.apache.http.util.EntityUtils'
 
 ruboto_import_widgets :LinearLayout, :TextView, :ImageView
-require_relative 'speech_listener.rb'
 
 class RecognizeVoiceActivity
   def onCreate(bundle)

--- a/src/recognize_voice_activity.rb
+++ b/src/recognize_voice_activity.rb
@@ -34,7 +34,7 @@ class RecognizeVoiceActivity
     if network
       is_online = network.is_connected_or_connecting
       if is_online
-        if $is_first_launch == nil
+        if $is_first_launch.nil?
           thread = Thread.start do
             begin
               notify_slack_ohayoman_status '10'
@@ -59,7 +59,7 @@ class RecognizeVoiceActivity
 
   def onDestroy
     super
-    if $is_first_destroy == nil
+    if $is_first_destroy.nil?
       thread = Thread.start do
         begin
           notify_slack_ohayoman_status '11'
@@ -75,7 +75,7 @@ class RecognizeVoiceActivity
   end
 
   def start_recognize_voice(context)
-    if $speech_recognizer == nil
+    if $speech_recognizer.nil?
       recognition_listner = SpeechListener.new(self)
       $speech_recognizer = SpeechRecognizer.create_speech_recognizer(context)
       $speech_recognizer.set_recognition_listener(recognition_listner)

--- a/src/recognize_voice_activity.rb
+++ b/src/recognize_voice_activity.rb
@@ -75,21 +75,22 @@ class RecognizeVoiceActivity
   end
 
   def start_recognize_voice(context)
-    recognition_listner = SpeechListener.new(self)
-    @speech_recognizer = SpeechRecognizer.create_speech_recognizer(context)
-    @speech_recognizer.set_recognition_listener(recognition_listner)
-    intent = Intent.new(RecognizerIntent::ACTION_RECOGNIZE_SPEECH)
-    intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE, 'ja_JP')
-    intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE_MODEL,
-                    RecognizerIntent::LANGUAGE_MODEL_FREE_FORM)
-    intent.putExtra(RecognizerIntent::EXTRA_PROMPT, 'Please Speech')
+    if $speech_recognizer == nil
+      recognition_listner = SpeechListener.new(self)
+      $speech_recognizer = SpeechRecognizer.create_speech_recognizer(context)
+      $speech_recognizer.set_recognition_listener(recognition_listner)
 
+      $recognizing_voice_intent = Intent.new(RecognizerIntent::ACTION_RECOGNIZE_SPEECH)
+      $recognizing_voice_intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE, 'ja_JP')
+      $recognizing_voice_intent.putExtra(RecognizerIntent::EXTRA_LANGUAGE_MODEL,
+                                         RecognizerIntent::LANGUAGE_MODEL_FREE_FORM)
+    end
     # 音声のMute,unMute処理を繰り返し行うには、Activity全体で1つのAudioManagerを使わなければいけないルール。
     # リスナーでも同じManagerを使えるよう，Global変数にしている．
     $audio_manager = @context.getSystemService(Context::AUDIO_SERVICE)
-    $audio_manager.setStreamMute(AudioManager::STREAM_MUSIC, true)
+    $audio_manager.setStreamMute(AudioManager::STREAM_SYSTEM, true)
 
-    @speech_recognizer.start_listening(intent)
+    $speech_recognizer.start_listening($recognizing_voice_intent)
   end
 
   def notify_slack_ohayoman_status status

--- a/src/speech_listener.rb
+++ b/src/speech_listener.rb
@@ -61,6 +61,7 @@ class SpeechListener
       $player_otsukare.start
       continue_recognizing_voice :otsukare
     else
+      reset_media_players
       @activity.start_ruboto_activity 'RecognizeVoiceActivity'
     end
   end

--- a/src/speech_listener.rb
+++ b/src/speech_listener.rb
@@ -5,19 +5,6 @@ java_import 'android.net.Uri'
 class SpeechListener
   def initialize(activity)
     @activity = activity
-    @context = activity.getApplicationContext
-
-    ohayo_sound_ids = [R.raw.ohayo1, R.raw.ohayo2, R.raw.ohayo3, R.raw.ohayo4, R.raw.ohayo5, R.raw.ohayo6, R.raw.ohayo7, R.raw.ohayo8]
-    otsukare_sound_ids = [R.raw.otsukare1, R.raw.otsukare2, R.raw.otsukare3, R.raw.otsukare4, R.raw.otsukare5, R.raw.otsukare6, R.raw.otsukare7, R.raw.otsukare8, R.raw.otsukare9, R.raw.otsukare10, R.raw.otsukare11, R.raw.otsukare12]
-
-    ohayo_sound_resid = ohayo_sound_ids[rand(8)]
-    otsukare_sound_resid = otsukare_sound_ids[rand(12)]
-
-    @player_ohayo = MediaPlayer.new
-    @player_otsukare = MediaPlayer.new
-
-    prepare_greeting_player @player_ohayo, ohayo_sound_resid
-    prepare_greeting_player @player_otsukare, otsukare_sound_resid
   end
 
   def hashCode
@@ -34,6 +21,7 @@ class SpeechListener
   end
 
   def onError(error)
+    reset_media_players
     # REVIEW スタイルガイドに忠実に従えば、if文で改行すべきだが、これくらいなら改行しない方が読みやすいのでは？
     @activity.start_ruboto_activity 'RecognizeVoiceActivity'
   end
@@ -58,7 +46,7 @@ class SpeechListener
       || result[0] == 'はようございます' \
       || result[0] == 'おはよう ございます'
 
-      @player_ohayo.start
+      $player_ohayo.start
       continue_recognizing_voice :ohayo
     elsif result[0] == 'お疲れ様です' \
       || result[0] == 'お疲れさまです' \
@@ -70,7 +58,7 @@ class SpeechListener
       || result[0] == 'します' \
       || result[0] == '先にします'
 
-      @player_otsukare.start
+      $player_otsukare.start
       continue_recognizing_voice :otsukare
     else
       @activity.start_ruboto_activity 'RecognizeVoiceActivity'
@@ -83,14 +71,16 @@ class SpeechListener
   def continue_recognizing_voice greeting
     if greeting == :ohayo
       loop do
-        unless @player_ohayo.isPlaying
+        unless $player_ohayo.isPlaying
+          reset_media_players
           @activity.start_ruboto_activity 'RecognizeVoiceActivity'
           break
         end
       end
     elsif greeting == :otsukare
       loop do
-        unless @player_otsukare.isPlaying
+        unless $player_otsukare.isPlaying
+          reset_media_players
           @activity.start_ruboto_activity 'RecognizeVoiceActivity'
           break
         end
@@ -98,10 +88,8 @@ class SpeechListener
     end
   end
 
-  def prepare_greeting_player player, greeting_resid
-    greeting_uri = Uri.parse("android.resource://com.ohayoman_app/#{greeting_resid}")
-    player.set_data_source(@context, greeting_uri)
-    player.set_audio_stream_type(AudioManager::STREAM_DTMF)
-    player.prepare
+  def reset_media_players
+    $player_ohayo.reset
+    $player_otsukare.reset
   end
 end


### PR DESCRIPTION
# 背景
## 詳細

音声認識の処理で、エラーコード7のエラー(No recognition result matched)が1度発生すると、エラーコード8(ERROR_RECOGNIZER_BUSY)のエラーが発生し続け、音声認識が正常に動かなくなっていた。
## 原因

すべての処理を通じて、SpeechRecognizerは1つまでしかインスタンス化してはいけないらしいが、Activityを開始する度にSpeechRecognizerをインスタンス化していた。
(ソース : http://stackoverflow.com/questions/12381995/error-8-in-speech-recognition-android)
# 実装
- SpeechRecognizerを、初めてActivityを開始する際にのみインスタンス化し、グローバル変数として使い回す。
- 音声データのランダム選択処理を、何度も行われるstart_recognize_voiceメソッドの中に移動。
  - SpeechRecognizerを1度しかインスタンス化しないことに伴い、SpeechListenerのintialize処理が1度しか実行されないため、音声データのランダム選択が1度しか行われず、1つの挨拶しか再生されなくなった。
- require_relativeの位置を、一連のrequire処理の下に移動
  - 統一感を出すため
